### PR TITLE
Add Hyper-V vs WSL2 into the issue template, remove mention of edge

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!--
 Please, check https://docs.docker.com/docker-for-windows/troubleshoot/.
-Issues without logs and details cannot be debugged, and will be closed.
+Issues without a clear description, logs and details cannot be debugged, and will be closed.
+Please give your issue a clear title, not just a one-word statement or a diagnostics ID.
 
 Issues unrelated to Docker Desktop will be closed.  In particular, see
   - https://github.com/moby/moby/issues for Docker daemon, e.g. running on Windows Server with Docker EE
@@ -9,15 +10,17 @@ Issues unrelated to Docker Desktop will be closed.  In particular, see
   - https://github.com/docker/docker.github.io/issues for the documentation
 -->
 
-<!-- Click these checkboxes after submitting. -->
-<!-- Download Docker Desktop 'Edge' (latest build) here: https://hub.docker.com/editions/community/docker-ce-desktop-windows -->
-  - [ ] I have tried with the latest version of my channel (Stable or Edge)
+<!-- Click these checkboxes after submitting, or place an "x" in them. -->
+  - [ ] I have tried with the latest version of Docker Desktop
+  - [ ] I have tried disabling enabled experimental features
   - [ ] I have uploaded Diagnostics
   - Diagnostics ID:
-
-### Expected behavior
+  - [ ] I am using the Docker WSL2 Backend
+  - [ ] I am using the Docker Hyper-V Backend
 
 ### Actual behavior
+
+### Expected behavior
 
 ### Information
 <!--
@@ -29,6 +32,7 @@ Please, help us understand the problem.  For instance:
 -->
   - Windows Version:
   - Docker Desktop Version:
+  - WSL2 or Hyper-V backend?  
   - Are you running inside a virtualized Windows e.g. on a cloud server or on a mac VM:
 
 ### Steps to reproduce the behavior


### PR DESCRIPTION
Various fiddles, but it's super important to know if people are on WSL2 back-end
And since the edge versions have been discontinued, remove that verbiage.